### PR TITLE
test: add database test environment and coverage

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# Local database used only for unit tests
+# Example:
+# DATABASE_TEST_URL=postgresql://postgres:postgres@localhost:5433/shop_comparison_test
+DATABASE_TEST_URL=postgresql://postgres:postgres@localhost:5433/shop_comparison_test

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,3 @@
+# Local database used only for unit tests
+# Set this value in your local .env.test or CI secrets.
+DATABASE_TEST_URL=postgresql://postgres:postgres@localhost:5433/shop_comparison_test

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.test
 .envrc
 .venv
 env/

--- a/docker-compose.dbtest.yml
+++ b/docker-compose.dbtest.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:16
+    container_name: shop-test-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: shop_comparison_test
+    ports:
+      - '5433:5432'
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d shop_comparison_test']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_test_data:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "This repository contains the server-side logic, database management, and business orchestration layer for the Shop Comparison Platform. It serves as the central hub that processes data from various scrapers, manages the product catalog, and provides a high-performance API for the frontend.",
   "main": "index.js",
   "scripts": {
-<<<<<<< HEAD
-    "test": "prisma validate"
-=======
     "start": "nest start backend",
     "start:dev": "nest start backend --watch",
     "start:debug": "nest start backend --debug --watch",
@@ -19,7 +16,6 @@
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
     "prisma:migrate": "prisma migrate dev"
->>>>>>> b508ebf (chore: set up database test environment)
   },
   "keywords": [],
   "author": "",
@@ -27,17 +23,31 @@
   "type": "commonjs",
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.12.0",
+    "@nestjs/cli": "^11.0.21",
+    "@nestjs/testing": "^11.1.19",
+    "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
+    "@types/supertest": "^7.2.0",
+    "jest": "^30.3.0",
     "prisma": "^7.6.0",
     "prisma-docs-generator": "^0.8.0",
     "prisma-erd-generator": "^2.4.2",
+    "supertest": "^7.2.2",
+    "ts-jest": "^29.4.9",
+    "ts-loader": "^9.5.7",
     "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "@nestjs/common": "^11.1.19",
+    "@nestjs/core": "^11.1.19",
+    "@nestjs/platform-express": "^11.1.19",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,22 @@
   "description": "This repository contains the server-side logic, database management, and business orchestration layer for the Shop Comparison Platform. It serves as the central hub that processes data from various scrapers, manages the product catalog, and provides a high-performance API for the frontend.",
   "main": "index.js",
   "scripts": {
+<<<<<<< HEAD
     "test": "prisma validate"
+=======
+    "start": "nest start backend",
+    "start:dev": "nest start backend --watch",
+    "start:debug": "nest start backend --debug --watch",
+    "build": "nest build backend",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:db": "jest --config ./src/db-tests/jest.db.config.js",
+    "test:db:watch": "jest --config ./src/db-tests/jest.db.config.js --watch",
+    "test:e2e": "jest --config ./apps/backend/test/jest-e2e.json",
+    "prisma:generate": "prisma generate",
+    "prisma:studio": "prisma studio",
+    "prisma:migrate": "prisma migrate dev"
+>>>>>>> b508ebf (chore: set up database test environment)
   },
   "keywords": [],
   "author": "",

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -61,4 +61,35 @@ describe('Prisma Database Unit Tests (Local Test DB)', () => {
     });
   });
 
+  describe('Category and Product cluster', () => {
+    it('creates category hierarchy and product', async () => {
+      const rootCategory = await prisma.productCategory.create({
+        data: { name: 'Food' },
+      });
+
+      const childCategory = await prisma.productCategory.create({
+        data: {
+          name: 'Dairy',
+          parentId: rootCategory.id,
+        },
+      });
+
+      const product = await prisma.product.create({
+        data: {
+          productId: 'MILK-001',
+          canonicalName: 'Milk',
+          brand: 'Local Farm',
+          media: 'https://example.com/milk.jpg',
+          measurements: { volume: '1L' },
+          pricingLogic: { unit: 'item' },
+          calories: 61,
+          categoryId: childCategory.id,
+        },
+      });
+
+      expect(product.id).toBeDefined();
+      expect(product.categoryId).toBe(childCategory.id);
+    });
+  });
+
 });

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client';
+import { clearDatabase, disconnectDatabase, getPrisma, resetSchemaAndMigrate } from './test-db.client';
+
+const prisma = getPrisma();
+
+describe('Prisma Database Unit Tests (Local Test DB)', () => {
+  beforeAll(async () => {
+    await resetSchemaAndMigrate();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  it('runs a placeholder test', async () => {
+    expect(true).toBe(true);
+  });
+
+});

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -16,8 +16,49 @@ describe('Prisma Database Unit Tests (Local Test DB)', () => {
     await disconnectDatabase();
   });
 
-  it('runs a placeholder test', async () => {
-    expect(true).toBe(true);
+  describe('User and Cart cluster', () => {
+    it('creates user and enforces unique email', async () => {
+      await prisma.user.create({
+        data: {
+          name: 'Alice',
+          email: 'alice@test.local',
+          password: 'secret',
+        },
+      });
+
+      await expect(
+        prisma.user.create({
+          data: {
+            name: 'Alice Duplicate',
+            email: 'alice@test.local',
+            password: 'secret',
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('cascades cart deletion when user is removed', async () => {
+      const user = await prisma.user.create({
+        data: {
+          name: 'Bob',
+          email: 'bob@test.local',
+          password: 'secret',
+        },
+      });
+
+      await prisma.cart.create({
+        data: {
+          userId: user.id,
+          sum: new Prisma.Decimal('0'),
+          discountSum: new Prisma.Decimal('0'),
+        },
+      });
+
+      await prisma.user.delete({ where: { id: user.id } });
+
+      const carts = await prisma.cart.findMany({ where: { userId: user.id } });
+      expect(carts.length).toBe(0);
+    });
   });
 
 });

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -92,4 +92,94 @@ describe('Prisma Database Unit Tests (Local Test DB)', () => {
     });
   });
 
+  describe('Store, Offer and Price History cluster', () => {
+    it('enforces unique storeId + productId in offers', async () => {
+      const category = await prisma.productCategory.create({ data: { name: 'Snacks' } });
+      const product = await prisma.product.create({
+        data: {
+          productId: 'SNACK-001',
+          canonicalName: 'Chips',
+          media: 'https://example.com/chips.jpg',
+          measurements: { weight: '150g' },
+          pricingLogic: { unit: 'pack' },
+          categoryId: category.id,
+        },
+      });
+      const brand = await prisma.storeBrand.create({ data: { name: 'LocalMart' } });
+      const store = await prisma.localStore.create({
+        data: {
+          longitude: 30.5,
+          latitude: 50.4,
+          address: 'Main st 1',
+          openingHour: '08:00',
+          closingHour: '22:00',
+          city: 'Kyiv',
+          brandId: brand.id,
+        },
+      });
+
+      await prisma.offer.create({
+        data: {
+          storeId: store.id,
+          productId: product.id,
+          currentPrice: new Prisma.Decimal('55.50'),
+        },
+      });
+
+      await expect(
+        prisma.offer.create({
+          data: {
+            storeId: store.id,
+            productId: product.id,
+            currentPrice: new Prisma.Decimal('60.00'),
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('stores price history for an offer', async () => {
+      const category = await prisma.productCategory.create({ data: { name: 'Drinks' } });
+      const product = await prisma.product.create({
+        data: {
+          productId: 'DRINK-001',
+          canonicalName: 'Juice',
+          media: 'https://example.com/juice.jpg',
+          measurements: { volume: '1L' },
+          pricingLogic: { unit: 'item' },
+          categoryId: category.id,
+        },
+      });
+      const brand = await prisma.storeBrand.create({ data: { name: 'SuperStore' } });
+      const store = await prisma.localStore.create({
+        data: {
+          longitude: 30.6,
+          latitude: 50.45,
+          address: 'Main st 2',
+          openingHour: '08:00',
+          closingHour: '22:00',
+          city: 'Kyiv',
+          brandId: brand.id,
+        },
+      });
+      const offer = await prisma.offer.create({
+        data: {
+          storeId: store.id,
+          productId: product.id,
+          currentPrice: new Prisma.Decimal('49.99'),
+        },
+      });
+
+      await prisma.priceHistory.create({
+        data: {
+          offerId: offer.id,
+          price: new Prisma.Decimal('45.99'),
+          regularPrice: new Prisma.Decimal('49.99'),
+        },
+      });
+
+      const history = await prisma.priceHistory.findMany({ where: { offerId: offer.id } });
+      expect(history.length).toBe(1);
+    });
+  });
+
 });

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -210,4 +210,71 @@ describe('Prisma Database Unit Tests (Local Test DB)', () => {
     });
   });
 
+  describe('Recipe cluster', () => {
+    it('creates recipe with ingredients, equipment and reviews', async () => {
+      const productCategory = await prisma.productCategory.create({ data: { name: 'Vegetables' } });
+      const recipeCategory = await prisma.recipeCategory.create({ data: { name: 'Dinner' } });
+      const ingredient = await prisma.ingredient.create({
+        data: {
+          name: 'Tomato',
+          categoryId: productCategory.id,
+        },
+      });
+      const equipment = await prisma.equipment.create({
+        data: {
+          name: 'Pan',
+        },
+      });
+
+      const recipe = await prisma.recipe.create({
+        data: {
+          name: 'Tomato Pasta',
+          instructions: 'Cook pasta and add tomato sauce',
+          difficulty: 'Easy',
+          prepTime: 20,
+          servings: 2,
+          categoryId: recipeCategory.id,
+        },
+      });
+
+      await prisma.recipeIngredient.create({
+        data: {
+          recipeId: recipe.id,
+          ingredientId: ingredient.id,
+          quantity: 2,
+          unit: 'pcs',
+        },
+      });
+
+      await prisma.recipeEquipment.create({
+        data: {
+          recipeId: recipe.id,
+          equipmentId: equipment.id,
+          quantity: 1,
+        },
+      });
+
+      await prisma.review.create({
+        data: {
+          recipeId: recipe.id,
+          rate: 5,
+          comment: 'Excellent',
+        },
+      });
+
+      const fullRecipe = await prisma.recipe.findUnique({
+        where: { id: recipe.id },
+        include: {
+          ingredients: true,
+          equipment: true,
+          reviews: true,
+        },
+      });
+
+      expect(fullRecipe?.ingredients.length).toBe(1);
+      expect(fullRecipe?.equipment.length).toBe(1);
+      expect(fullRecipe?.reviews.length).toBe(1);
+    });
+  });
+
 });

--- a/src/db-tests/database.db.test.ts
+++ b/src/db-tests/database.db.test.ts
@@ -182,4 +182,32 @@ describe('Prisma Database Unit Tests (Local Test DB)', () => {
     });
   });
 
+  describe('Diet and Allergen cluster', () => {
+    it('enforces unique diet name per user', async () => {
+      const user = await prisma.user.create({
+        data: {
+          name: 'Diet User',
+          email: 'diet@test.local',
+          password: 'secret',
+        },
+      });
+
+      await prisma.diet.create({
+        data: {
+          userId: user.id,
+          name: 'Keto',
+        },
+      });
+
+      await expect(
+        prisma.diet.create({
+          data: {
+            userId: user.id,
+            name: 'Keto',
+          },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
 });

--- a/src/db-tests/jest.db.config.js
+++ b/src/db-tests/jest.db.config.js
@@ -6,7 +6,12 @@ module.exports = {
   testMatch: ['**/*.db.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/src/db-tests/tsconfig.json',
+      },
+    ],
   },
   setupFiles: ['<rootDir>/src/db-tests/jest.db.setup.js'],
   testTimeout: 60000,

--- a/src/db-tests/jest.db.config.js
+++ b/src/db-tests/jest.db.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rootDir: '../..',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src/db-tests'],
+  testMatch: ['**/*.db.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  setupFiles: ['<rootDir>/src/db-tests/jest.db.setup.js'],
+  testTimeout: 60000,
+};

--- a/src/db-tests/jest.db.setup.js
+++ b/src/db-tests/jest.db.setup.js
@@ -1,0 +1,9 @@
+const dotenv = require('dotenv');
+
+dotenv.config({ path: '.env.test' });
+
+if (!process.env.DATABASE_TEST_URL) {
+  throw new Error(
+    'DATABASE_TEST_URL is required for database unit tests. Create .env.test with a local PostgreSQL URL.',
+  );
+}

--- a/src/db-tests/test-db.client.ts
+++ b/src/db-tests/test-db.client.ts
@@ -1,0 +1,106 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { Pool } from 'pg';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+let pool: Pool | null = null;
+let prisma: PrismaClient | null = null;
+
+function getLocalTestDatabaseUrl(): string {
+  const url = process.env.DATABASE_TEST_URL;
+
+  if (!url) {
+    throw new Error('DATABASE_TEST_URL is not set. Configure a local PostgreSQL test database URL.');
+  }
+
+  const isLocal = /localhost|127\.0\.0\.1|::1/.test(url);
+  if (!isLocal) {
+    throw new Error('DATABASE_TEST_URL must point to localhost/127.0.0.1 for safe local testing.');
+  }
+
+  return url;
+}
+
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: getLocalTestDatabaseUrl() });
+  }
+  return pool;
+}
+
+export function getPrisma(): PrismaClient {
+  if (!prisma) {
+    prisma = new PrismaClient({
+      adapter: new PrismaPg(getPool()),
+    });
+  }
+  return prisma;
+}
+
+export async function resetSchemaAndMigrate(): Promise<void> {
+  const pg = getPool();
+
+  const exists = await pg.query("SELECT to_regclass('public.users') AS regclass");
+  const usersTableExists = Boolean(exists.rows[0]?.regclass);
+
+  if (usersTableExists) {
+    return;
+  }
+
+  const migrationsDir = join(process.cwd(), 'prisma', 'migrations');
+  const migrationFolders = readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const folder of migrationFolders) {
+    const migrationSqlPath = join(migrationsDir, folder, 'migration.sql');
+    const sql = readFileSync(migrationSqlPath, 'utf8').trim();
+    if (sql.length > 0) {
+      await pg.query(sql);
+    }
+  }
+}
+
+export async function clearDatabase(): Promise<void> {
+  const pg = getPool();
+
+  await pg.query(`
+    TRUNCATE TABLE
+      cart_items,
+      price_history,
+      user_favourites,
+      recipe_ingredients,
+      recipe_equipment,
+      reviews,
+      offers,
+      carts,
+      favourite_products,
+      favourite_recipes,
+      favourite_stores,
+      diets,
+      allergens,
+      product,
+      recipes,
+      ingredients,
+      equipment,
+      local_store,
+      store_brand,
+      pr_categories,
+      rec_categories,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  if (prisma) {
+    await prisma.$disconnect();
+    prisma = null;
+  }
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/src/db-tests/tsconfig.json
+++ b/src/db-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
 Added a separate test environment for running database tests through Docker Compose. Configured a local PostgreSQL database for integration checks, updated the test execution setup, and added coverage for the main database entities through tests.

## What’s included:

- created a dedicated docker-compose.dbtest.yml for the test database;
- configured connection via DATABASE_TEST_URL
- added db-test configuration for Jest/TypeScript;
- wrote tests for the main cluster scenarios:
  - `User and Cart`
  - `Category and Product`
  - `Store, Offer and Price History`
  - `Diet and Allergen`
  - `Recipe`
## Note:
The tests verify basic constraints, relations, and cascade behavior in the database.