### PR TITLE
refactor(db): make discountCondition column nullable in prisma schema

### DIFF
--- a/prisma/migrations/20260526135059_make_discount_condition_nullable/migration.sql
+++ b/prisma/migrations/20260526135059_make_discount_condition_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "offers" ALTER COLUMN "discount_condition" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,7 +198,7 @@ model Offer {
   createdAt         DateTime       @default(now())
   updatedAt         DateTime       @updatedAt
   discountPrice     Decimal?       @map("discount_price") @db.Decimal(12, 2)
-  discountCondition String         @default("[]") @map("discount_condition")
+  discountCondition String?        @default("[]") @map("discount_condition")
   storeSku          String?        @map("store_sku")
   cartItems         CartItem[]     @relation("OfferToCartItem")
   product           Product        @relation("ProductToOffer", fields: [productId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
This PR updates the Prisma schema by making the discountCondition column nullable to better support discounts without predefined conditions.