### PR TITLE
feat(auth): implement local sign-up/sign-in endpoints and session auth

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Req,
+  Body,
   HttpCode,
   HttpStatus,
   UseGuards,
@@ -12,10 +13,41 @@ import { AuthService } from "./auth.service";
 import { GetUser } from "./core/get-user.decorator";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 import { Public } from "./core/public.decorator";
+import { SignUpDto } from "./dto/sign-up.dto";
+import { SignInDto } from "./dto/sign-in.dto";
 
 @Controller("auth")
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  // Sign up with email/password
+  @Public()
+  @Post("/signup")
+  @HttpCode(HttpStatus.CREATED)
+  async signUp(@Body() body: SignUpDto) {
+    const user = await this.authService.registerWithEmail(
+      body.email,
+      body.password,
+      body.name,
+    );
+    return { user };
+  }
+
+  // Sign in with email/password -> returns a session token
+  @Public()
+  @Post("/signin")
+  @HttpCode(HttpStatus.OK)
+  async signIn(@Req() req: any, @Body() body: SignInDto) {
+    const ip = req.ip;
+    const userAgent = req.headers["user-agent"] as string | undefined;
+    const { user, token } = await this.authService.authenticateWithEmail(
+      body.email,
+      body.password,
+      ip,
+      userAgent,
+    );
+    return { user, token };
+  }
 
   // Verify a bearer token and create a session
   @Public()
@@ -31,7 +63,12 @@ export class AuthController {
     const user = await this.authService.validateTokenAndGetUser(token);
     if (!user) throw new UnauthorizedException();
 
-    await this.authService.createSessionForToken(user.id, token ?? "", req.ip, req.headers["user-agent"] as string);
+    await this.authService.createSessionForToken(
+      user.id,
+      token ?? "",
+      req.ip,
+      req.headers["user-agent"] as string,
+    );
 
     return { user };
   }

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,12 +1,19 @@
-import { Injectable } from "@nestjs/common";
+import {
+  Injectable,
+  ConflictException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import { BetterAuthService } from "./better-auth.service";
+import * as bcrypt from "bcrypt";
+import { randomBytes } from "crypto";
 
 const DEFAULT_SESSION_TTL_DAYS = Number(process.env.SESSION_TTL_DAYS ?? 30);
 
 @Injectable()
 export class AuthService {
-  private readonly providerId = process.env.BETTER_AUTH_PROVIDER_ID || "better-auth";
+  private readonly providerId =
+    process.env.BETTER_AUTH_PROVIDER_ID || "better-auth";
 
   constructor(
     private readonly prisma: PrismaService,
@@ -35,13 +42,16 @@ export class AuthService {
         where: { accountId, providerId: this.providerId },
       });
       if (account) {
-        const user = await this.prisma.user.findUnique({ where: { id: account.userId } });
+        const user = await this.prisma.user.findUnique({
+          where: { id: account.userId },
+        });
         if (user) return user;
       }
     }
 
     // Create a new user when we have at least an account id or email
-    const emailForNew = email ?? (accountId ? `${accountId}@${this.providerId}.local` : null);
+    const emailForNew =
+      email ?? (accountId ? `${accountId}@${this.providerId}.local` : null);
     if (!emailForNew) return null;
 
     const name = (payload as any).name ?? "";
@@ -74,7 +84,9 @@ export class AuthService {
     userAgent?: string,
     expiresAt?: Date,
   ) {
-    const ttl = expiresAt ?? new Date(Date.now() + DEFAULT_SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
+    const ttl =
+      expiresAt ??
+      new Date(Date.now() + DEFAULT_SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
     return this.prisma.session.create({
       data: {
         token,
@@ -95,7 +107,47 @@ export class AuthService {
   async getUserBySessionToken(token: string) {
     const session = await this.prisma.session.findUnique({ where: { token } });
     if (!session) return null;
-    const user = await this.prisma.user.findUnique({ where: { id: session.userId } });
+    const user = await this.prisma.user.findUnique({
+      where: { id: session.userId },
+    });
     return user;
+  }
+
+  /** Register a new user with email/password */
+  async registerWithEmail(email: string, password: string, name?: string) {
+    const existing = await this.prisma.user.findUnique({ where: { email } });
+    if (existing)
+      throw new ConflictException("User with this email already exists");
+
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await this.prisma.user.create({
+      data: {
+        email,
+        password: hashed,
+        name: name || email,
+      },
+    });
+
+    return user;
+  }
+
+  /** Authenticate user by email/password and create a session token */
+  async authenticateWithEmail(
+    email: string,
+    password: string,
+    ip?: string,
+    userAgent?: string,
+  ) {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user || !user.password) throw new UnauthorizedException();
+
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) throw new UnauthorizedException();
+
+    // Create a random token and session
+    const token = randomBytes(48).toString("hex");
+    await this.createSessionForToken(user.id, token, ip, userAgent);
+
+    return { user, token };
   }
 }

--- a/apps/backend/src/auth/dto/sign-in.dto.ts
+++ b/apps/backend/src/auth/dto/sign-in.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from "class-validator";
+
+export class SignInDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/apps/backend/src/auth/dto/sign-up.dto.ts
+++ b/apps/backend/src/auth/dto/sign-up.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsOptional, IsString, MinLength } from "class-validator";
+
+export class SignUpDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}


### PR DESCRIPTION
This PR introduces a local authentication system with sign-up and sign-in endpoints, along with session-based authentication support.

# Authentication
- Added local user registration (sign-up)
- Added local user authentication (sign-in)
- Implemented session creation and token generation
- Added support for authenticated access using Bearer tokens
- Added password hashing with bcrypt
# API Endpoints
- Added POST /auth/signup
- Added POST /auth/signin
# DTOs
- Added sign-up.dto.ts
- Added sign-in.dto.ts